### PR TITLE
Fix CI to run on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   ci:


### PR DESCRIPTION
The workflow was configured for 'main' but this repo uses 'master'. This fixes CI so it runs on every push and PR.