### PR TITLE
Fix NODE_OPTIONS to use absolute path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    env:
+      NODE_OPTIONS: --require ${{ github.workspace }}/node-compat.cjs
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,27 +25,18 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-        env:
-          NODE_OPTIONS: --require ./node-compat.cjs
 
       - name: Generate Prisma client
         run: npx prisma generate
-        env:
-          NODE_OPTIONS: --require ./node-compat.cjs
 
       - name: Lint
         run: npm run lint
-        env:
-          NODE_OPTIONS: --require ./node-compat.cjs
 
       - name: Test
         run: npx vitest run
-        env:
-          NODE_OPTIONS: --require ./node-compat.cjs
 
       - name: Build
         run: next build
         env:
-          NODE_OPTIONS: --require ./node-compat.cjs
           # ANTHROPIC_API_KEY is optional — app falls back to MockLanguageModel without it
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Using ./node-compat.cjs was relative to each script's working dir (broke during Prisma postinstall). Using ${{ github.workspace }} gives an absolute path that works everywhere.