### PR TITLE
Remove NODE_OPTIONS from CI (not needed on Node 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
-    env:
-      NODE_OPTIONS: --require ${{ github.workspace }}/node-compat.cjs
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
node-compat.cjs patches a Node 25+ localStorage SSR bug. CI runs Node 20 where the bug doesn't exist, so NODE_OPTIONS is unnecessary and was crashing every job.