### PR TITLE
Fix CI lint step for Next.js 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: npx prisma generate
 
       - name: Lint
-        run: npm run lint
+        run: npx eslint src --ext .ts,.tsx,.js,.jsx --max-warnings 0
 
       - name: Test
         run: npx vitest run


### PR DESCRIPTION
next lint is broken in Next.js 16 (treats 'lint' as a directory). Switch to running eslint directly.